### PR TITLE
Add facet metadata for Algolia search filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+---
+# Facet metadata
+section: Plugins
+---
+
 <!-- START_METADATA
 ---
 title: Shopware Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
----
-# Facet metadata
-section: Plugins
----
-
 <!-- START_METADATA
 ---
 title: Shopware Changelog
@@ -10,6 +5,7 @@ sidebar_position: 100
 description: All notable changes to the Shopware plugin will be documented in this file.
 pagination_next: null
 pagination_prev: null
+section: Plugins
 ---
 END_METADATA -->
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
----
-# Facet metadata
-section: Plugins
----
-
 <!-- START_METADATA
 ---
 title: "Vipps/MobilePay for Shopware plugin"
@@ -10,6 +5,7 @@ sidebar_position: 1
 description: Provide Vipps and MobilePay payments for Shopware.
 pagination_next: null
 pagination_prev: null
+section: Plugins
 ---
 END_METADATA -->
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+---
+# Facet metadata
+section: Plugins
+---
+
 <!-- START_METADATA
 ---
 title: "Vipps/MobilePay for Shopware plugin"

--- a/docs/adjust_payments.md
+++ b/docs/adjust_payments.md
@@ -1,8 +1,3 @@
----
-# Facet metadata
-section: Plugins
----
-
 <!-- START_METADATA
 ---
 title: Adjust payments
@@ -11,6 +6,7 @@ sidebar_position: 20
 description: How to adjust payments with the Shopware Payments plugin
 pagination_next: null
 pagination_prev: null
+section: Plugins
 ---
 END_METADATA -->
 

--- a/docs/adjust_payments.md
+++ b/docs/adjust_payments.md
@@ -1,3 +1,8 @@
+---
+# Facet metadata
+section: Plugins
+---
+
 <!-- START_METADATA
 ---
 title: Adjust payments

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -1,8 +1,3 @@
----
-# Facet metadata
-section: Plugins
----
-
 <!-- START_METADATA
 ---
 title: Install and configure Shopware
@@ -11,6 +6,7 @@ sidebar_position: 10
 description: How to install and configure the Shopware Payments plugin
 pagination_next: null
 pagination_prev: null
+section: Plugins
 ---
 END_METADATA -->
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -1,3 +1,8 @@
+---
+# Facet metadata
+section: Plugins
+---
+
 <!-- START_METADATA
 ---
 title: Install and configure Shopware

--- a/docs/enhanced_logging.md
+++ b/docs/enhanced_logging.md
@@ -1,8 +1,3 @@
----
-# Facet metadata
-section: Plugins
----
-
 <!-- START_METADATA
 ---
 title: Enhanced logging
@@ -11,6 +6,7 @@ sidebar_position: 30
 description: How to Enable enhanced logging for the Shopware Payments plugin
 pagination_next: null
 pagination_prev: null
+section: Plugins
 ---
 END_METADATA -->
 

--- a/docs/enhanced_logging.md
+++ b/docs/enhanced_logging.md
@@ -1,3 +1,8 @@
+---
+# Facet metadata
+section: Plugins
+---
+
 <!-- START_METADATA
 ---
 title: Enhanced logging


### PR DESCRIPTION
## Summary

This PR adds `section: Plugins` to the frontmatter of markdown files to enable faceted search filtering in the [Vipps MobilePay developer documentation](https://developer.vippsmobilepay.com).

## Changes

- Added `# Facet metadata` section to frontmatter
- Set `section: Plugins` for all documentation files

## Why this is needed

The Vipps MobilePay developer documentation uses Algolia for search. By adding these meta tags to the frontmatter, they are converted to `docsearch:section` HTML meta tags that Algolia's crawler extracts. This enables users to filter search results by section (Plugins, APIs, Knowledge Base, etc.).

## Testing

- [ ] Verify frontmatter is valid YAML
- [ ] Build the documentation site to ensure no errors
- [ ] After merge and deployment, verify meta tags appear in HTML